### PR TITLE
Add ability to set permissions on a globus dir

### DIFF
--- a/lib/globus/client/endpoint.rb
+++ b/lib/globus/client/endpoint.rb
@@ -4,7 +4,7 @@ require 'faraday'
 
 module Globus
   class Client
-    # The namespace for the "login" command
+    # The namespace for endpoint API operations
     class Endpoint
       def initialize(token)
         @token = token
@@ -20,16 +20,22 @@ module Globus
         )
       end
 
+      def endpoint
+        "/v0.10/operation/endpoint/#{Settings.globus.endpoint}"
+      end
+
       # This is a temporary method to show parsing of data returned.
       def length
         objects['total']
       end
 
       # Create a directory https://docs.globus.org/api/transfer/file_operations/#make_directory
-      def mk_dir(sunet:, work_id:, version:)
-        sunet = sunet.delete_suffix('@stanford.edu')
+      # @param sunetid [String] sunetid (not email address)
+      # @param work_id [String] the h2 work id
+      # @param version [String] the h2 work's version number
+      def mk_dir(sunetid:, work_id:, version:)
         path = Settings.globus.uploads_dir
-        dirs = [sunet, work_id, "version#{version}"]
+        dirs = [sunetid, "work#{work_id}", "version#{version}"]
 
         # transfer API does not support recursive directory creation
         dirs.each do |dir|
@@ -47,24 +53,57 @@ module Globus
         end
       end
 
+      # Assign a user read/write permissions for a directory https://docs.globus.org/api/transfer/acl/#rest_access_create
+      # @param sunetid [String] sunetid (not email address)
+      # @param work_id [String] the h2 work id
+      # @param version [String] the h2 work's version number
+      def set_permissions(sunetid:, work_id:, version:)
+        path = "#{Settings.globus.uploads_dir}/#{sunetid}/work#{work_id}/version#{version}/"
+        identity = Globus::Client::Identity.new(token)
+        id = identity.get_identity_id(sunetid)
+        call_access(path:, id:, sunetid:)
+      end
+
       private
 
       # @return [Faraday::Response]
       def call_mkdir(path)
-        endpoint = "/v0.10/operation/endpoint/#{Settings.globus.endpoint}/mkdir"
-        connection.post(endpoint) do |req|
+        response = connection.post("#{endpoint}/mkdir") do |req|
           req.headers['Content-Type'] = 'application/json'
           req.body = {
             DATA_TYPE: 'mkdir',
             path:
           }.to_json
         end
+        UnexpectedResponse.call(response) unless response.success?
+
+        response
+      end
+
+      # @param path [String] the directory on the globus endpoint
+      # @param id [String] globus identifier associated with the sunetid email
+      # @param sunetid [String] sunetid, not email address
+      # @return [Faraday::Response]
+      def call_access(path:, id:, sunetid:)
+        response = connection.post("#{endpoint}/access") do |req|
+          req.body = {
+            DATA_TYPE: 'access',
+            principal_type: 'identity',
+            principal: id,
+            path:,
+            permissions: 'rw',
+            notify_email: "#{sunetid}@stanford.edu"
+          }.to_json
+          req.headers['Content-Type'] = 'application/json'
+        end
+        UnexpectedResponse.call(response) unless response.success?
+
+        response
       end
 
       def objects
         # List files at an endpoint https://docs.globus.org/api/transfer/file_operations/#list_directory_contents
-        endpoint = "/v0.10/operation/endpoint/#{Settings.globus.endpoint}/ls"
-        response = connection.get(endpoint)
+        response = connection.get("#{endpoint}/ls")
         UnexpectedResponse.call(response) unless response.success?
         JSON.parse(response.body)
       end

--- a/lib/globus/client/identity.rb
+++ b/lib/globus/client/identity.rb
@@ -26,9 +26,8 @@ module Globus
         end
       end
 
-      def get_identity_id(email)
-        @email = email
-        raise StandardError, "Identity #{email} should be in form of: sunet@stanford.edu." unless valid?(@email)
+      def get_identity_id(sunetid)
+        @email = "#{sunetid}@stanford.edu"
 
         response = lookup_identity
         UnexpectedResponse.call(response) unless response.success?
@@ -38,12 +37,6 @@ module Globus
       end
 
       private
-
-      def valid?(email)
-        return true if email.end_with? '@stanford.edu'
-
-        false
-      end
 
       def extract_id(data)
         identities = data['identities']

--- a/spec/globus/client/identity_spec.rb
+++ b/spec/globus/client/identity_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Globus::Client::Identity do
   let(:client_secret) { Settings.globus.client_secret }
   let(:globus_client) { Globus::Client.new(client_id, client_secret) }
   let(:identity) { described_class.new(globus_client.token) }
-  let(:email) { 'example@stanford.edu' }
+  let(:sunetid) { 'example' }
   let(:token_response) do
     {
       access_token: 'a_long_silly_token',
@@ -42,34 +42,7 @@ RSpec.describe Globus::Client::Identity do
     end
 
     it '#get_identity' do
-      expect(identity.get_identity_id(email)).to eq '12345abc'
-    end
-  end
-
-  context 'with an invalid sunet email' do
-    let(:email) { 'example@example.com' }
-    let(:identity_response) do
-      {
-        'identities': [{
-          'name': 'Jane Tester',
-          'email': 'example@example.com',
-          'id': '12345abc',
-          'organization': 'Stanford University',
-          'identity_type': 'login',
-          'username': 'example@example.com',
-          'identity_provider': 'example-identity-provider',
-          'status': 'used'
-        }]
-      }
-    end
-
-    before do
-      stub_request(:post, "#{Settings.globus.auth_url}/v2/oauth2/token")
-        .to_return(status: 200, body: token_response.to_json)
-    end
-
-    it '#get_identity' do
-      expect { identity.get_identity_id(email) }.to raise_error(StandardError)
+      expect(identity.get_identity_id(sunetid)).to eq '12345abc'
     end
   end
 
@@ -98,7 +71,7 @@ RSpec.describe Globus::Client::Identity do
     end
 
     it '#get_identity' do
-      expect { identity.get_identity_id(email) }.to raise_error(StandardError)
+      expect { identity.get_identity_id(sunetid) }.to raise_error(StandardError)
     end
   end
 
@@ -127,7 +100,7 @@ RSpec.describe Globus::Client::Identity do
     end
 
     it 'raises a ForbiddenError' do
-      expect { identity.get_identity_id(email) }.to raise_error(Globus::Client::UnexpectedResponse::ForbiddenError)
+      expect { identity.get_identity_id(sunetid) }.to raise_error(Globus::Client::UnexpectedResponse::ForbiddenError)
     end
   end
 end


### PR DESCRIPTION
## Why was this change made? 🤔

Resolves #8 to set permissions for a user on their upload directory. I also changed the former "email" param in some methods to a sunetid, to match what we're usually working with in h2 and did a little refactoring.

## How was this change tested? 🤨
Unit tests. 

⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test) that use sdr-api*** (e.g.create_object_h2_spec.rb) and/or test in [stage|qa] environment, in addition to specs. ⚡


