### PR TITLE
Fix console binstub and add missing update script

### DIFF
--- a/.autoupdate/postupdate
+++ b/.autoupdate/postupdate
@@ -1,0 +1,19 @@
+#!/bin/bash --login
+
+# This script is called by our weekly dependency update job in Jenkins after updating Ruby and other deps
+
+# Switch to Ruby 3.1 for Globus::Client (3.0 is default in Jenkinsfile)
+rvm use 3.1.2@globus_client --create &&
+    gem install bundler &&
+    bundle install --gemfile Gemfile
+
+standardrb --fix > globus_client_standard.txt
+
+retVal=$?
+
+git commit -am "Update to latest standard style guide"
+
+if [ $retVal -ne 0 ]; then
+    echo "ERROR UPDATING RUBY TO STANDARD STYLE (globus_client)"
+    cat globus_client_standard.txt
+fi

--- a/bin/console
+++ b/bin/console
@@ -2,7 +2,7 @@
 # frozen_string_literal: true
 
 require "bundler/setup"
-require "globus_client"
+require "globus/client"
 
 # You can add fixtures and/or initialization code here to make experimenting
 # with your gem easier. You can also use a different console, if you like.

--- a/globus_client.gemspec
+++ b/globus_client.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.
   spec.files = Dir.chdir(__dir__) do
-    `git ls-files -z`.split('\x0').reject do |f|
+    `git ls-files -z`.split("\x0").reject do |f|
       (f == __FILE__) || f.match(%r{\A(?:(?:bin|test|spec|features)/|\.(?:git|travis|circleci)|appveyor)})
     end
   end

--- a/lib/globus/client/unexpected_response.rb
+++ b/lib/globus/client/unexpected_response.rb
@@ -39,8 +39,8 @@ module Globus
           raise ResourceNotFound, "Resource does not exist or is missing."
         when 409
           raise ConflictError,
-            'Request is blocked, disallowed, or not consistent with the state of the service,
-                 e.g. trying to cancel a task which has already completed?'
+            "Request is blocked, disallowed, or not consistent with the state of the service,
+                 e.g. trying to cancel a task which has already completed?"
         when 502
           raise EndpointError, "Other error with endpoint."
         when 503


### PR DESCRIPTION
# Why was this change made? 🤔

* Use double-quotes around null byte specifier
  * Without this commit, the app and its builds were completely broken.
* Fix console binstub
  * The console binstub was generated with the wrong path to the client. This commit makes `bin/console` functional. 
    ```shell
    # BEFORE
    $ bin/console
    bin/console:5:in `require': cannot load such file -- globus_client (LoadError)
            from bin/console:5:in `<main>'
    ```
    
    ```shell
    # AFTER
    $ bin/console
    3.1.2 :001 >
    ```
* Add missing standardrb auto-fix update script
  * We are currently exploring using standardrb for our Ruby linting needs (instead of plain Rubocop), and part of using standardrb is using its excellent auto-fix functionality when the versions of rubocop and rubocop-performance change behind the scenes. This script was already present in Argo and should be present in every codebase using standardrb, such as globus_client.

# How was this change tested? 🤨

CI
