### PR TITLE
Refactor `Endpoint` class

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    globus_client (0.1.0)
+    globus_client (0.2.0)
       activesupport (>= 4.2, < 8)
       faraday
       zeitwerk
@@ -106,4 +106,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   2.3.19
+   2.3.26


### PR DESCRIPTION
# Why was this change made? 🤔

This commit moves code around and renames things, intended for clarity and to group like information.

* Inline `#call_mkdir` and `#call_access` since they're no longer super-long and they're integral to understanding what `#mkdir` and `#set_permissions` do
* Rename `#endpoint` to `#base_url` so it's clearer what role that method is playing in the class ("yo dawg i herd u like endpoints...")
* Extract `identity` to its own method


# How was this change tested? 🤨

CI
