### PR TITLE
Add API for disallowing writes to a directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,11 +58,25 @@ end
 
 ## Development
 
-After checking out the repo, run `bin/setup` to install dependencies. Then, run
-`rake spec` to run the tests. You can also run `bin/console` for an interactive
-prompt that will allow you to experiment.
+After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
 
 To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and the created tag, and push the `.gem` file to [rubygems.org](https://rubygems.org).
+
+### Integration Testing
+
+To test that the gem works against the Globus APIs, run `api_test.rb` via:
+
+```shell
+# the three args below are a user ID, a work ID, and a work version
+$ GLOBUS_CLIENT_ID=vault GLOBUS_CLIENT_SECRET=from_vault GLOBUS_ENDPOINT=from_shared_configs GLOBUS_UPLOADS_DIRECTORY=from_shared_configs ./api_test.rb mjgiarlo 987 1
+
+Initial directory permissions: rw
+Number of files in directory: 2
+Total size of files in directory: 66669
+Final directory permissions: r
+```
+
+Inspect the output and compare it to what you see in Globus Personal Connect to determine if behavior is correct.
 
 ## Contributing
 

--- a/api_test.rb
+++ b/api_test.rb
@@ -1,0 +1,34 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require "bundler/setup"
+require "globus/client"
+
+Globus::Client.configure(
+  client_id: ENV["GLOBUS_CLIENT_ID"],
+  client_secret: ENV["GLOBUS_CLIENT_SECRET"],
+  uploads_directory: ENV["GLOBUS_UPLOADS_DIRECTORY"],
+  transfer_endpoint_id: ENV["GLOBUS_ENDPOINT"]
+)
+
+user_id, work_id, work_version = *ARGV
+
+# Test public API methods here.
+Globus::Client.mkdir(user_id:, work_id:, work_version:)
+
+# Not part of the public API but this allows us to test access changes
+before_permissions = Globus::Client::Endpoint.new(Globus::Client.config, user_id: user_id, work_id: work_id, work_version: work_version).send(:access_rule)["permissions"]
+
+files_count = Globus::Client.file_count(user_id:, work_id:, work_version:)
+
+total_size = Globus::Client.total_size(user_id:, work_id:, work_version:)
+
+Globus::Client.disallow_writes(user_id:, work_id:, work_version:)
+
+# Not part of the public API but this allows us to test access changes
+after_permissions = Globus::Client::Endpoint.new(Globus::Client.config, user_id: user_id, work_id: work_id, work_version: work_version).send(:access_rule)["permissions"]
+
+puts "Initial directory permissions: #{before_permissions}"
+puts "Number of files in directory: #{files_count}"
+puts "Total size of files in directory: #{total_size}"
+puts "Final directory permissions: #{after_permissions}"

--- a/lib/globus/client.rb
+++ b/lib/globus/client.rb
@@ -36,7 +36,7 @@ module Globus
         self
       end
 
-      delegate :config, :file_count, :mkdir, :total_size, to: :instance
+      delegate :config, :disallow_writes, :file_count, :mkdir, :total_size, to: :instance
 
       def default_transfer_url
         "https://transfer.api.globusonline.org"
@@ -53,6 +53,11 @@ module Globus
       endpoint = Globus::Client::Endpoint.new(config, ...)
       endpoint.mkdir
       endpoint.allow_writes
+    end
+
+    def disallow_writes(...)
+      endpoint = Globus::Client::Endpoint.new(config, ...)
+      endpoint.disallow_writes
     end
 
     def file_count(...)

--- a/lib/globus/client.rb
+++ b/lib/globus/client.rb
@@ -52,7 +52,7 @@ module Globus
     def mkdir(...)
       endpoint = Globus::Client::Endpoint.new(config, ...)
       endpoint.mkdir
-      endpoint.set_permissions
+      endpoint.allow_writes
     end
 
     def file_count(...)

--- a/lib/globus/client/endpoint.rb
+++ b/lib/globus/client/endpoint.rb
@@ -48,7 +48,7 @@ module Globus
       end
 
       # Assign a user read/write permissions for a directory https://docs.globus.org/api/transfer/acl/#rest_access_create
-      def set_permissions
+      def allow_writes
         response = connection.post(access_path) do |req|
           req.body = {
             DATA_TYPE: "access",

--- a/lib/globus/client/endpoint.rb
+++ b/lib/globus/client/endpoint.rb
@@ -49,13 +49,57 @@ module Globus
 
       # Assign a user read/write permissions for a directory https://docs.globus.org/api/transfer/acl/#rest_access_create
       def allow_writes
+        access_request(permissions: "rw")
+      end
+
+      # Assign a user read-only permissions for a directory https://docs.globus.org/api/transfer/acl/#rest_access_create
+      def disallow_writes
+        access_request(permissions: "r")
+      end
+
+      private
+
+      attr_reader :config, :user_id, :work_id, :work_version
+
+      def connection
+        # Transfer API connection
+        Faraday.new(
+          url: config.transfer_url,
+          headers: {Authorization: "Bearer #{config.token}"}
+        )
+      end
+
+      def user
+        Identity.new(config).get_identity_id(user_id)
+      end
+
+      # Builds up a path from a list of path elements. E.g., input would look like:
+      #     ["mjgiarlo", "work123", "version1"]
+      # And this method returns:
+      #     ["/uploads/mjgiarlo/", "/uploads/mjgiarlo/work123/", "/uploads/mjgiarlo/work123/version1/"]
+      def paths
+        path_segments.map.with_index do |_segment, index|
+          File.join(config.uploads_directory, path_segments.slice(..index)).concat("/")
+        end
+      end
+
+      # @see #paths
+      def full_path
+        paths.last
+      end
+
+      def path_segments
+        [user_id, "work#{work_id}", "version#{work_version}"]
+      end
+
+      def access_request(permissions:)
         response = connection.post(access_path) do |req|
           req.body = {
             DATA_TYPE: "access",
             principal_type: "identity",
-            principal: identity.get_identity_id(user_id),
-            path: paths.last,
-            permissions: "rw",
+            principal: user,
+            path: full_path,
+            permissions:,
             notify_email: "#{user_id}@stanford.edu"
           }.to_json
           req.headers["Content-Type"] = "application/json"
@@ -72,42 +116,16 @@ module Globus
         UnexpectedResponse.call(response)
       end
 
-      private
-
-      attr_reader :config, :user_id, :work_id, :work_version
-
-      def connection
-        # Transfer API connection
-        Faraday.new(
-          url: config.transfer_url,
-          headers: {Authorization: "Bearer #{config.token}"}
-        )
-      end
-
-      def identity
-        Globus::Client::Identity.new(config)
-      end
-
-      # Builds up a path from a list of path elements. E.g., input would look like:
-      #     ["mjgiarlo", "work123", "version1"]
-      # And this method returns:
-      #     ["/uploads/mjgiarlo/", "/uploads/mjgiarlo/work123/", "/uploads/mjgiarlo/work123/version1/"]
-      def paths
-        path_segments.map.with_index do |_segment, index|
-          File.join(config.uploads_directory, path_segments.slice(..index)).concat("/")
-        end
-      end
-
-      def path_segments
-        [user_id, "work#{work_id}", "version#{work_version}"]
-      end
-
       def objects
         # List files at an endpoint https://docs.globus.org/api/transfer/file_operations/#list_directory_contents
-        response = connection.get("#{transfer_path}/ls?path=#{paths.last}")
+        response = connection.get("#{transfer_path}/ls?path=#{full_path}")
         return JSON.parse(response.body) if response.success?
 
         UnexpectedResponse.call(response)
+      end
+
+      def files
+        objects["DATA"].select { |object| object["DATA_TYPE"] == "file" }
       end
 
       def transfer_path
@@ -116,10 +134,6 @@ module Globus
 
       def access_path
         "/v0.10/endpoint/#{config.transfer_endpoint_id}/access"
-      end
-
-      def files
-        objects["DATA"].select { |object| object["DATA_TYPE"] == "file" }
       end
     end
   end

--- a/spec/globus/client/endpoint_spec.rb
+++ b/spec/globus/client/endpoint_spec.rb
@@ -265,7 +265,7 @@ RSpec.describe Globus::Client::Endpoint do
       allow(Globus::Client::Identity).to receive(:new).and_return(fake_identity)
     end
 
-    context "when allow writes to a directory" do
+    context "when no access rules are present for a directory" do
       let(:access_response) do
         {
           code: "Created",
@@ -276,8 +276,29 @@ RSpec.describe Globus::Client::Endpoint do
           message: "Access rule created successfully."
         }
       end
+      let(:access_list_response) do
+        {
+          DATA_TYPE: "access_list",
+          endpoint: transfer_endpoint_id,
+          DATA: [
+            {
+              DATA_TYPE: "access",
+              create_time: "2022-11-22T16:08:24+00:00",
+              id: "e3ee1ec2-6a7f-11ed-b0bd-bfe7e7197080",
+              path: "/foo/bar/",
+              permissions: "rw",
+              principal: "ae3e3f70-4065-408b-9cd8-39dc01b07d29",
+              principal_type: "identity",
+              role_id: nil,
+              role_type: nil
+            }
+          ]
+        }
+      end
 
       before do
+        stub_request(:get, "#{config.transfer_url}/v0.10/endpoint/#{transfer_endpoint_id}/access_list")
+          .to_return(status: 200, body: access_list_response.to_json)
         stub_request(:post, "#{config.transfer_url}/v0.10/endpoint/#{transfer_endpoint_id}/access")
           .to_return(status: 201, body: access_response.to_json)
       end
@@ -287,19 +308,42 @@ RSpec.describe Globus::Client::Endpoint do
       end
     end
 
-    context "when re-allowing writes to on a directory" do
+    context "when access rules are present for a directory" do
       let(:access_response) do
         {
-          code: "Exists",
-          message: "This folder is already shared with this identity. If you would like to change the read/write access level, please delete this permission and then add a new permission with the desired access level.",
+          code: "Updated",
+          message: "Access rule '123' permissions updated successfully",
           request_id: "abc123",
-          resource: "/endpoint/epname/access"
+          resource: "/endpoint/epname/access",
+          DATA_TYPE: "result"
         }
       end
+      let(:access_list_response) do
+        {
+          DATA_TYPE: "access_list",
+          endpoint: transfer_endpoint_id,
+          DATA: [
+            {
+              DATA_TYPE: "access",
+              create_time: "2022-11-22T16:08:24+00:00",
+              id: access_rule_id,
+              path: "/uploads/example/work123/version1/",
+              permissions: "rw",
+              principal: "ae3e3f70-4065-408b-9cd8-39dc01b07d29",
+              principal_type: "identity",
+              role_id: nil,
+              role_type: nil
+            }
+          ]
+        }
+      end
+      let(:access_rule_id) { "e3ee1ec2-6a7f-11ed-b0bd-bfe7e7197080" }
 
       before do
-        stub_request(:post, "#{config.transfer_url}/v0.10/endpoint/#{transfer_endpoint_id}/access")
-          .to_return(status: 409, body: access_response.to_json)
+        stub_request(:get, "#{config.transfer_url}/v0.10/endpoint/#{transfer_endpoint_id}/access_list")
+          .to_return(status: 200, body: access_list_response.to_json)
+        stub_request(:put, "#{config.transfer_url}/v0.10/endpoint/#{transfer_endpoint_id}/access/#{access_rule_id}")
+          .to_return(status: 200, body: access_response.to_json)
       end
 
       it "does not raise an exception" do
@@ -307,7 +351,7 @@ RSpec.describe Globus::Client::Endpoint do
       end
     end
 
-    context "when allowing writes to an invalid directory" do
+    context "when directory is invalid" do
       let(:access_response) do
         {
           code: "InvalidPath",
@@ -318,8 +362,29 @@ RSpec.describe Globus::Client::Endpoint do
           message: "Invalid Path"
         }
       end
+      let(:access_list_response) do
+        {
+          DATA_TYPE: "access_list",
+          endpoint: transfer_endpoint_id,
+          DATA: [
+            {
+              DATA_TYPE: "access",
+              create_time: "2022-11-22T16:08:24+00:00",
+              id: "e3ee1ec2-6a7f-11ed-b0bd-bfe7e7197080",
+              path: "/foo/bar/",
+              permissions: "rw",
+              principal: "ae3e3f70-4065-408b-9cd8-39dc01b07d29",
+              principal_type: "identity",
+              role_id: nil,
+              role_type: nil
+            }
+          ]
+        }
+      end
 
       before do
+        stub_request(:get, "#{config.transfer_url}/v0.10/endpoint/#{transfer_endpoint_id}/access_list")
+          .to_return(status: 200, body: access_list_response.to_json)
         stub_request(:post, "#{config.transfer_url}/v0.10/endpoint/#{transfer_endpoint_id}/access")
           .to_return(status: 400, body: access_response.to_json)
       end
@@ -337,7 +402,7 @@ RSpec.describe Globus::Client::Endpoint do
       allow(Globus::Client::Identity).to receive(:new).and_return(fake_identity)
     end
 
-    context "when disallowing writes to a directory" do
+    context "when no access rules are present for a directory" do
       let(:access_response) do
         {
           code: "Created",
@@ -348,8 +413,29 @@ RSpec.describe Globus::Client::Endpoint do
           message: "Access rule created successfully."
         }
       end
+      let(:access_list_response) do
+        {
+          DATA_TYPE: "access_list",
+          endpoint: transfer_endpoint_id,
+          DATA: [
+            {
+              DATA_TYPE: "access",
+              create_time: "2022-11-22T16:08:24+00:00",
+              id: "e3ee1ec2-6a7f-11ed-b0bd-bfe7e7197080",
+              path: "/foo/bar/",
+              permissions: "rw",
+              principal: "ae3e3f70-4065-408b-9cd8-39dc01b07d29",
+              principal_type: "identity",
+              role_id: nil,
+              role_type: nil
+            }
+          ]
+        }
+      end
 
       before do
+        stub_request(:get, "#{config.transfer_url}/v0.10/endpoint/#{transfer_endpoint_id}/access_list")
+          .to_return(status: 200, body: access_list_response.to_json)
         stub_request(:post, "#{config.transfer_url}/v0.10/endpoint/#{transfer_endpoint_id}/access")
           .to_return(status: 201, body: access_response.to_json)
       end
@@ -359,19 +445,42 @@ RSpec.describe Globus::Client::Endpoint do
       end
     end
 
-    context "when re-disallowing writes to a directory" do
+    context "when access rules are present for a directory" do
       let(:access_response) do
         {
-          code: "Exists",
-          message: "This folder is already shared with this identity. If you would like to change the read/write access level, please delete this permission and then add a new permission with the desired access level.",
+          code: "Updated",
+          message: "Access rule '123' permissions updated successfully",
           request_id: "abc123",
-          resource: "/endpoint/epname/access"
+          resource: "/endpoint/epname/access",
+          DATA_TYPE: "result"
         }
       end
+      let(:access_list_response) do
+        {
+          DATA_TYPE: "access_list",
+          endpoint: transfer_endpoint_id,
+          DATA: [
+            {
+              DATA_TYPE: "access",
+              create_time: "2022-11-22T16:08:24+00:00",
+              id: access_rule_id,
+              path: "/uploads/example/work123/version1/",
+              permissions: "rw",
+              principal: "ae3e3f70-4065-408b-9cd8-39dc01b07d29",
+              principal_type: "identity",
+              role_id: nil,
+              role_type: nil
+            }
+          ]
+        }
+      end
+      let(:access_rule_id) { "e3ee1ec2-6a7f-11ed-b0bd-bfe7e7197080" }
 
       before do
-        stub_request(:post, "#{config.transfer_url}/v0.10/endpoint/#{transfer_endpoint_id}/access")
-          .to_return(status: 409, body: access_response.to_json)
+        stub_request(:get, "#{config.transfer_url}/v0.10/endpoint/#{transfer_endpoint_id}/access_list")
+          .to_return(status: 200, body: access_list_response.to_json)
+        stub_request(:put, "#{config.transfer_url}/v0.10/endpoint/#{transfer_endpoint_id}/access/#{access_rule_id}")
+          .to_return(status: 200, body: access_response.to_json)
       end
 
       it "does not raise an exception" do
@@ -379,7 +488,7 @@ RSpec.describe Globus::Client::Endpoint do
       end
     end
 
-    context "when disallowing writes to an invalid directory" do
+    context "when directory is invalid" do
       let(:access_response) do
         {
           code: "InvalidPath",
@@ -390,8 +499,29 @@ RSpec.describe Globus::Client::Endpoint do
           message: "Invalid Path"
         }
       end
+      let(:access_list_response) do
+        {
+          DATA_TYPE: "access_list",
+          endpoint: transfer_endpoint_id,
+          DATA: [
+            {
+              DATA_TYPE: "access",
+              create_time: "2022-11-22T16:08:24+00:00",
+              id: "e3ee1ec2-6a7f-11ed-b0bd-bfe7e7197080",
+              path: "/foo/bar/",
+              permissions: "rw",
+              principal: "ae3e3f70-4065-408b-9cd8-39dc01b07d29",
+              principal_type: "identity",
+              role_id: nil,
+              role_type: nil
+            }
+          ]
+        }
+      end
 
       before do
+        stub_request(:get, "#{config.transfer_url}/v0.10/endpoint/#{transfer_endpoint_id}/access_list")
+          .to_return(status: 200, body: access_list_response.to_json)
         stub_request(:post, "#{config.transfer_url}/v0.10/endpoint/#{transfer_endpoint_id}/access")
           .to_return(status: 400, body: access_response.to_json)
       end

--- a/spec/globus/client/endpoint_spec.rb
+++ b/spec/globus/client/endpoint_spec.rb
@@ -258,7 +258,7 @@ RSpec.describe Globus::Client::Endpoint do
     end
   end
 
-  describe "#set_permissions" do
+  describe "#allow_writes" do
     let(:fake_identity) do
       instance_double(Globus::Client::Identity, get_identity_id: "example")
     end
@@ -285,7 +285,7 @@ RSpec.describe Globus::Client::Endpoint do
       end
 
       it "does not raise an exception" do
-        expect { endpoint.set_permissions }.not_to raise_error
+        expect { endpoint.allow_writes }.not_to raise_error
       end
     end
 
@@ -305,7 +305,7 @@ RSpec.describe Globus::Client::Endpoint do
       end
 
       it "does not raise an exception" do
-        expect { endpoint.set_permissions }.not_to raise_error
+        expect { endpoint.allow_writes }.not_to raise_error
       end
     end
 
@@ -327,7 +327,7 @@ RSpec.describe Globus::Client::Endpoint do
       end
 
       it "raises a BadRequestError" do
-        expect { endpoint.set_permissions }.to raise_error(Globus::Client::UnexpectedResponse::BadRequestError)
+        expect { endpoint.allow_writes }.to raise_error(Globus::Client::UnexpectedResponse::BadRequestError)
       end
     end
   end

--- a/spec/globus/client_spec.rb
+++ b/spec/globus/client_spec.rb
@@ -120,7 +120,7 @@ RSpec.describe Globus::Client do
   end
 
   describe "public instance methods" do
-    let(:fake_endpoint) { instance_double(described_class::Endpoint, mkdir: nil, set_permissions: nil, file_count: 3, total_size: 3333) }
+    let(:fake_endpoint) { instance_double(described_class::Endpoint, mkdir: nil, allow_writes: nil, file_count: 3, total_size: 3333) }
 
     before do
       allow(described_class::Endpoint).to receive(:new).and_return(fake_endpoint)

--- a/spec/globus/client_spec.rb
+++ b/spec/globus/client_spec.rb
@@ -83,67 +83,32 @@ RSpec.describe Globus::Client do
     end
   end
 
-  describe "public class methods" do
-    let(:fake_instance) do
-      instance_double(
-        described_class,
-        mkdir: nil,
-        file_count: nil,
-        total_size: nil
-      )
-    end
+  [:file_count, :mkdir, :total_size].each do |method|
+    describe ".#{method}" do
+      let(:fake_instance) { instance_double(described_class) }
 
-    before do
-      allow(described_class).to receive(:instance).and_return(fake_instance)
-    end
+      before do
+        allow(described_class).to receive(:instance).and_return(fake_instance)
+        allow(fake_instance).to receive(method)
+      end
 
-    describe ".mkdir" do
-      it "invokes mkdir on the Endpoint class, injecting config" do
-        described_class.mkdir
-        expect(fake_instance).to have_received(:mkdir).once
+      it "invokes instance##{method}" do
+        described_class.public_send(method)
+        expect(fake_instance).to have_received(method).once
       end
     end
 
-    describe ".file_count" do
-      it "invokes file_count on the Endpoint class, injecting config" do
-        described_class.file_count
-        expect(fake_instance).to have_received(:file_count).once
+    describe "##{method}" do
+      let(:fake_endpoint) { instance_double(described_class::Endpoint, allow_writes: nil) }
+
+      before do
+        allow(described_class::Endpoint).to receive(:new).and_return(fake_endpoint)
+        allow(fake_endpoint).to receive(method)
       end
-    end
 
-    describe ".total_size" do
-      it "invokes total_size on the Endpoint class, injecting config" do
-        described_class.total_size
-        expect(fake_instance).to have_received(:total_size).once
-      end
-    end
-  end
-
-  describe "public instance methods" do
-    let(:fake_endpoint) { instance_double(described_class::Endpoint, mkdir: nil, allow_writes: nil, file_count: 3, total_size: 3333) }
-
-    before do
-      allow(described_class::Endpoint).to receive(:new).and_return(fake_endpoint)
-    end
-
-    describe "#mkdir" do
-      it "invokes mkdir on the Endpoint class, injecting config" do
-        client.mkdir
-        expect(fake_endpoint).to have_received(:mkdir).once
-      end
-    end
-
-    describe "#file_count" do
-      it "returns the number of files" do
-        client.file_count
-        expect(fake_endpoint).to have_received(:file_count).once
-      end
-    end
-
-    describe "#total_size" do
-      it "returns the size of all files for the path" do
-        client.total_size
-        expect(fake_endpoint).to have_received(:total_size).once
+      it "invokes Endpoint##{method}" do
+        client.public_send(method)
+        expect(fake_endpoint).to have_received(method).once
       end
     end
   end

--- a/spec/globus/client_spec.rb
+++ b/spec/globus/client_spec.rb
@@ -83,7 +83,7 @@ RSpec.describe Globus::Client do
     end
   end
 
-  [:file_count, :mkdir, :total_size].each do |method|
+  [:disallow_writes, :file_count, :mkdir, :total_size].each do |method|
     describe ".#{method}" do
       let(:fake_instance) { instance_double(described_class) }
 


### PR DESCRIPTION
Fixes #36

# Why was this change made? 🤔

This commit adds the ability to disallow writes to a directory (i.e., make a directory read-only) to the public API. As part of this work, add a minor refactoring of the access-related components within the `Endpoint` class for greater code re-use. Also includes:
* Establish a new pattern for streamlined testing of `Client` public API
* Rename `Endpoint#set_permissions` to `Endpoint#allow_writes`
* Allow access changes to handle rule creation and rule updates
* Add and document an integration test for devs.

# How was this change tested? 🤨

CI and ran the integration test
