### PR TITLE
Help autoloaders by creating lib/globus_client.rb

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ If bundler is not being used to manage dependencies, install the gem by executin
 For one-off requests:
 
 ```ruby
-require 'globus/client'
+require 'globus_client'
 
 # NOTE: The settings below live in the consumer, not in the gem.
 client = Globus::Client.configure(

--- a/api_test.rb
+++ b/api_test.rb
@@ -2,7 +2,7 @@
 # frozen_string_literal: true
 
 require "bundler/setup"
-require "globus/client"
+require "globus_client"
 
 Globus::Client.configure(
   client_id: ENV["GLOBUS_CLIENT_ID"],

--- a/bin/console
+++ b/bin/console
@@ -2,7 +2,7 @@
 # frozen_string_literal: true
 
 require "bundler/setup"
-require "globus/client"
+require "globus_client"
 
 # You can add fixtures and/or initialization code here to make experimenting
 # with your gem easier. You can also use a different console, if you like.

--- a/lib/globus_client.rb
+++ b/lib/globus_client.rb
@@ -1,0 +1,1 @@
+require "globus/client"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,7 +5,7 @@ SimpleCov.start do
   add_filter "spec"
 end
 
-require "globus/client"
+require "globus_client"
 require "byebug"
 require "webmock/rspec"
 


### PR DESCRIPTION
## Why was this change made? 🤔

This allows dependent codebases to autoload the gem without requiring an explicit `require "globus/client"`.



## How was this change tested? 🤨

CI
