### PR TITLE
Remove unused and unnecessary Ruby 3 type signatures

### DIFF
--- a/sig/globus_client.rbs
+++ b/sig/globus_client.rbs
@@ -1,4 +1,0 @@
-module GlobusClient
-  VERSION: String
-  # See the writing guide of rbs: https://github.com/ruby/rbs#guides
-end


### PR DESCRIPTION
## Why was this change made? 🤔

Tidy things up and stop suggesting we're using type checking.

## How was this change tested? 🤨

CI

