### PR TITLE
Refactor endpoint to be less coupled to H2

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,9 +31,9 @@ client = GlobusClient.configure(
   uploads_directory: Settings.globus.uploads_directory,
   transfer_endpoint_id: Settings.globus.transfer_endpoint_id
 )
-client.mkdir(user_id: 'mjgiarlo', work_id: 1234, work_version: 1)
+client.mkdir(user_id: 'mjgiarlo@stanford.edu', path: 'mjgiarlo/work1234/version1')
 
-result = client.user_exists?('mjgiarlo')
+result = client.user_exists?('mjgiarlo@stanford.edu')
 ```
 
 You can also invoke methods directly on the client class, which is useful in a
@@ -53,7 +53,7 @@ GlobusClient.configure(
 # app/services/my_globus_service.rb
 # ...
 def create_user_directory
-  GlobusClient.mkdir(user_id: 'mjgiarlo', work_id: 1234, work_version: 1)
+  GlobusClient.mkdir(user_id: 'mjgiarlo@stanford.edu', path: 'mjgiarlo/work1234/version1')
 end
 # ...
 ```

--- a/api_test.rb
+++ b/api_test.rb
@@ -11,24 +11,24 @@ GlobusClient.configure(
   transfer_endpoint_id: ENV["GLOBUS_ENDPOINT"]
 )
 
-user_id, work_id, work_version = *ARGV
+user_id, path = *ARGV
 
 # Test public API methods here.
-GlobusClient.mkdir(user_id:, work_id:, work_version:)
+GlobusClient.mkdir(user_id:, path:)
 
 user_exists = GlobusClient.user_exists?(user_id)
 
 # Not part of the public API but this allows us to test access changes
-before_permissions = GlobusClient::Endpoint.new(GlobusClient.config, user_id: user_id, work_id: work_id, work_version: work_version).send(:access_rule)["permissions"]
+before_permissions = GlobusClient::Endpoint.new(GlobusClient.config, user_id:, path:).send(:access_rule)["permissions"]
 
-files_count = GlobusClient.file_count(user_id:, work_id:, work_version:)
+files_count = GlobusClient.file_count(user_id:, path:)
 
-total_size = GlobusClient.total_size(user_id:, work_id:, work_version:)
+total_size = GlobusClient.total_size(user_id:, path:)
 
-GlobusClient.disallow_writes(user_id:, work_id:, work_version:)
+GlobusClient.disallow_writes(user_id:, path:)
 
 # Not part of the public API but this allows us to test access changes
-after_permissions = GlobusClient::Endpoint.new(GlobusClient.config, user_id: user_id, work_id: work_id, work_version: work_version).send(:access_rule)["permissions"]
+after_permissions = GlobusClient::Endpoint.new(GlobusClient.config, user_id:, path:).send(:access_rule)["permissions"]
 
 puts "User #{user_id} exists: #{user_exists}"
 puts "Initial directory permissions: #{before_permissions}"

--- a/lib/globus_client/identity.rb
+++ b/lib/globus_client/identity.rb
@@ -7,8 +7,8 @@ class GlobusClient
       @config = config
     end
 
-    def get_identity_id(sunetid)
-      @email = "#{sunetid}@stanford.edu"
+    def get_identity_id(user_id)
+      @email = user_id
 
       response = lookup_identity
       UnexpectedResponse.call(response) unless response.success?
@@ -17,8 +17,8 @@ class GlobusClient
       extract_id(data)
     end
 
-    def exists?(sunetid)
-      get_identity_id(sunetid)
+    def exists?(user_id)
+      get_identity_id(user_id)
       true
     rescue
       false

--- a/spec/globus_client/endpoint_spec.rb
+++ b/spec/globus_client/endpoint_spec.rb
@@ -1,13 +1,14 @@
 # frozen_string_literal: true
 
 RSpec.describe GlobusClient::Endpoint do
-  subject(:endpoint) { described_class.new(config, user_id:, work_id:, work_version:) }
+  subject(:endpoint) { described_class.new(config, user_id:, path:) }
 
   let(:config) { OpenStruct.new(uploads_directory:, transfer_url:, transfer_endpoint_id:) }
   let(:transfer_endpoint_id) { "NOT_A_REAL_ENDPOINT" }
   let(:transfer_url) { "https://transfer.api.example.org" }
   let(:uploads_directory) { "/uploads/" }
-  let(:user_id) { "example" }
+  let(:user_id) { "example@stanford.edu" }
+  let(:path) { "example/work#{work_id}/version#{work_version}" }
   let(:work_id) { "123" }
   let(:work_version) { "1" }
   let(:mkdir_response) do
@@ -53,7 +54,7 @@ RSpec.describe GlobusClient::Endpoint do
       end
 
       before do
-        stub_request(:get, "#{config.transfer_url}/v0.10/operation/endpoint/#{transfer_endpoint_id}/ls?path=/uploads/example/work123/version1/")
+        stub_request(:get, "#{config.transfer_url}/v0.10/operation/endpoint/#{transfer_endpoint_id}/ls?path=/uploads/#{path}/")
           .to_return(status: 200, body: list_response.to_json)
       end
 
@@ -73,7 +74,7 @@ RSpec.describe GlobusClient::Endpoint do
       end
 
       before do
-        stub_request(:get, "#{config.transfer_url}/v0.10/operation/endpoint/#{transfer_endpoint_id}/ls?path=/uploads/example/work123/version1/")
+        stub_request(:get, "#{config.transfer_url}/v0.10/operation/endpoint/#{transfer_endpoint_id}/ls?path=/uploads/#{path}/")
           .to_return(status: 404, body: list_response.to_json)
       end
 
@@ -131,7 +132,7 @@ RSpec.describe GlobusClient::Endpoint do
       end
 
       before do
-        stub_request(:get, "#{config.transfer_url}/v0.10/operation/endpoint/#{transfer_endpoint_id}/ls?path=/uploads/example/work123/version1/")
+        stub_request(:get, "#{config.transfer_url}/v0.10/operation/endpoint/#{transfer_endpoint_id}/ls?path=/uploads/#{path}/")
           .to_return(status: 200, body: list_response.to_json)
       end
 
@@ -151,7 +152,7 @@ RSpec.describe GlobusClient::Endpoint do
       end
 
       before do
-        stub_request(:get, "#{config.transfer_url}/v0.10/operation/endpoint/#{transfer_endpoint_id}/ls?path=/uploads/example/work123/version1/")
+        stub_request(:get, "#{config.transfer_url}/v0.10/operation/endpoint/#{transfer_endpoint_id}/ls?path=/uploads/#{path}/")
           .to_return(status: 404, body: list_response.to_json)
       end
 
@@ -202,7 +203,7 @@ RSpec.describe GlobusClient::Endpoint do
           .to_return(status: 200, body: mkdir_response.to_json)
 
         stub_request(:post, "#{config.transfer_url}/v0.10/operation/endpoint/#{transfer_endpoint_id}/mkdir")
-          .with(body: {DATA_TYPE: "mkdir", path: "/uploads/example/work#{work_id}/version#{work_version}/"}.to_json)
+          .with(body: {DATA_TYPE: "mkdir", path: "/uploads/#{path}/"}.to_json)
           .to_return(status: 200, body: mkdir_response.to_json)
       end
 
@@ -237,7 +238,7 @@ RSpec.describe GlobusClient::Endpoint do
           .to_return(status: 200, body: mkdir_response.to_json)
 
         stub_request(:post, "#{config.transfer_url}/v0.10/operation/endpoint/#{transfer_endpoint_id}/mkdir")
-          .with(body: {DATA_TYPE: "mkdir", path: "/uploads/example/#{work_id}/#{work_version}/"}.to_json)
+          .with(body: {DATA_TYPE: "mkdir", path: "/uploads/#{path}/"}.to_json)
           .to_return(status: 200, body: mkdir_response.to_json)
       end
 
@@ -327,7 +328,7 @@ RSpec.describe GlobusClient::Endpoint do
               DATA_TYPE: "access",
               create_time: "2022-11-22T16:08:24+00:00",
               id: access_rule_id,
-              path: "/uploads/example/work123/version1/",
+              path: "/uploads/#{path}/",
               permissions: "rw",
               principal: "ae3e3f70-4065-408b-9cd8-39dc01b07d29",
               principal_type: "identity",
@@ -464,7 +465,7 @@ RSpec.describe GlobusClient::Endpoint do
               DATA_TYPE: "access",
               create_time: "2022-11-22T16:08:24+00:00",
               id: access_rule_id,
-              path: "/uploads/example/work123/version1/",
+              path: "/uploads/#{path}/",
               permissions: "rw",
               principal: "ae3e3f70-4065-408b-9cd8-39dc01b07d29",
               principal_type: "identity",

--- a/spec/globus_client/identity_spec.rb
+++ b/spec/globus_client/identity_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe GlobusClient::Identity do
   let(:client_id) { "client_id" }
   let(:client_secret) { "client_secret" }
   let(:config) { OpenStruct.new(auth_url:) }
-  let(:sunetid) { "example" }
+  let(:user_id) { "example@stanford.edu" }
   let(:token_response) do
     {
       access_token: "a_long_silly_token",
@@ -19,16 +19,16 @@ RSpec.describe GlobusClient::Identity do
     }
   end
 
-  context "with a valid sunet email" do
+  context "with a valid Globus ID" do
     let(:identity_response) do
       {
         identities: [{
           name: "Jane Tester",
-          email: "example@stanford.edu",
+          email: user_id,
           id: "12345abc",
           organization: "Stanford University",
           identity_type: "login",
-          username: "example@stanford.edu",
+          username: user_id,
           identity_provider: "example-identity-provider",
           status: "used"
         }]
@@ -39,19 +39,19 @@ RSpec.describe GlobusClient::Identity do
       stub_request(:post, "#{auth_url}/v2/oauth2/token")
         .to_return(status: 200, body: token_response.to_json)
 
-      stub_request(:get, "#{auth_url}/v2/api/identities?usernames=example@stanford.edu")
+      stub_request(:get, "#{auth_url}/v2/api/identities?usernames=#{user_id}")
         .to_return(status: 200, body: identity_response.to_json)
     end
 
     describe "#get_identity_id" do
       it "returns the globus user ID" do
-        expect(identity.get_identity_id(sunetid)).to eq "12345abc"
+        expect(identity.get_identity_id(user_id)).to eq "12345abc"
       end
     end
 
     describe "#exists?" do
       it "indicates that the user exists" do
-        expect(identity.exists?(sunetid)).to be true
+        expect(identity.exists?(user_id)).to be true
       end
     end
   end
@@ -61,11 +61,11 @@ RSpec.describe GlobusClient::Identity do
       {
         identities: [{
           name: "Jane Tester",
-          email: "example@stanford.edu",
+          email: user_id,
           id: "12345abc",
           organization: "Stanford University",
           identity_type: "login",
-          username: "example@stanford.edu",
+          username: user_id,
           identity_provider: "example-identity-provider",
           status: "unused"
         }]
@@ -76,19 +76,19 @@ RSpec.describe GlobusClient::Identity do
       stub_request(:post, "#{auth_url}/v2/oauth2/token")
         .to_return(status: 200, body: token_response.to_json)
 
-      stub_request(:get, "#{auth_url}/v2/api/identities?usernames=example@stanford.edu")
+      stub_request(:get, "#{auth_url}/v2/api/identities?usernames=#{user_id}")
         .to_return(status: 200, body: identity_response.to_json)
     end
 
     describe "#get_identity_id" do
       it "raises an error" do
-        expect { identity.get_identity_id(sunetid) }.to raise_error(RuntimeError, /No matching active Globus user found/)
+        expect { identity.get_identity_id(user_id) }.to raise_error(RuntimeError, /No matching active Globus user found/)
       end
     end
 
     describe "#exists?" do
       it "indicates that the user does not exist" do
-        expect(identity.exists?(sunetid)).to be false
+        expect(identity.exists?(user_id)).to be false
       end
     end
   end
@@ -113,12 +113,12 @@ RSpec.describe GlobusClient::Identity do
       stub_request(:post, "#{auth_url}/v2/oauth2/token")
         .to_return(status: 200, body: token_response.to_json)
 
-      stub_request(:get, "#{auth_url}/v2/api/identities?usernames=example@stanford.edu")
+      stub_request(:get, "#{auth_url}/v2/api/identities?usernames=#{user_id}")
         .to_return(status: 403, body: identity_response.to_json)
     end
 
     it "raises a ForbiddenError" do
-      expect { identity.get_identity_id(sunetid) }.to raise_error(GlobusClient::UnexpectedResponse::ForbiddenError)
+      expect { identity.get_identity_id(user_id) }.to raise_error(GlobusClient::UnexpectedResponse::ForbiddenError)
     end
   end
 
@@ -138,12 +138,12 @@ RSpec.describe GlobusClient::Identity do
       stub_request(:post, "#{auth_url}/v2/oauth2/token")
         .to_return(status: 200, body: token_response.to_json)
 
-      stub_request(:get, "#{auth_url}/v2/api/identities?usernames=example@stanford.edu")
+      stub_request(:get, "#{auth_url}/v2/api/identities?usernames=#{user_id}")
         .to_return(status: 401, body: identity_response.to_json)
     end
 
     it "raises an UnauthorizedError" do
-      expect { identity.get_identity_id(sunetid) }.to raise_error(GlobusClient::UnexpectedResponse::UnauthorizedError)
+      expect { identity.get_identity_id(user_id) }.to raise_error(GlobusClient::UnexpectedResponse::UnauthorizedError)
     end
   end
 end


### PR DESCRIPTION
## Why was this change made? 🤔

Fixes #23

Globus transfer operations do not need intimate knowledge of H2 concepts, such as works and versions. Instead, we need a path to operate on. Leave it to consumers like H2 to construct their own relative paths.

Also, decouple the Identity class from needing to know about SUNet IDs and email addresses, and instead expect a working Globus user ID (which just so happens to be a Stanford email).


## How was this change tested? 🤨

CI + successful runs of api_test.rb
