### PR TITLE
Get list of files for a filepath

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,10 @@ GlobusClient.configure(
 def create_user_directory
   GlobusClient.mkdir(user_id: 'mjgiarlo@stanford.edu', path: 'mjgiarlo/work1234/version1')
 end
+
+def lookup_dir_contents
+  GlobusClient.get_filenames(user_id: 'mjgiarlo@stanford.edu', path: 'mjgiarlo/work1234/version1')
+end
 # ...
 ```
 

--- a/api_test.rb
+++ b/api_test.rb
@@ -27,6 +27,8 @@ total_size = GlobusClient.total_size(user_id:, path:)
 
 GlobusClient.disallow_writes(user_id:, path:)
 
+files_list = GlobusClient.get_filenames(user_id:, path:)
+
 # Not part of the public API but this allows us to test access changes
 after_permissions = GlobusClient::Endpoint.new(GlobusClient.config, user_id:, path:).send(:access_rule)["permissions"]
 
@@ -34,4 +36,5 @@ puts "User #{user_id} exists: #{user_exists}"
 puts "Initial directory permissions: #{before_permissions}"
 puts "Number of files in directory: #{files_count}"
 puts "Total size of files in directory: #{total_size}"
+puts "List of files in directory: #{files_list}"
 puts "Final directory permissions: #{after_permissions}"

--- a/lib/globus_client.rb
+++ b/lib/globus_client.rb
@@ -32,7 +32,7 @@ class GlobusClient
       self
     end
 
-    delegate :config, :disallow_writes, :file_count, :mkdir, :total_size, :user_exists?, to: :instance
+    delegate :config, :disallow_writes, :file_count, :mkdir, :total_size, :user_exists?, :get_filenames, to: :instance
 
     def default_transfer_url
       "https://transfer.api.globusonline.org"
@@ -64,6 +64,11 @@ class GlobusClient
   def total_size(...)
     endpoint = Endpoint.new(config, ...)
     endpoint.total_size
+  end
+
+  def get_filenames(...)
+    endpoint = Endpoint.new(config, ...)
+    endpoint.get_filenames
   end
 
   def user_exists?(...)

--- a/spec/globus_client_spec.rb
+++ b/spec/globus_client_spec.rb
@@ -111,7 +111,7 @@ RSpec.describe GlobusClient do
     end
   end
 
-  [:disallow_writes, :file_count, :mkdir, :total_size].each do |method|
+  [:disallow_writes, :file_count, :mkdir, :total_size, :get_filenames].each do |method|
     describe ".#{method}" do
       let(:fake_instance) { instance_double(described_class) }
 


### PR DESCRIPTION
## Why was this change made? 🤔
Resolves #49 to return a list of files with their absolute filepath, when given an absolute path to a starting directory.

## How was this change tested? 🤨
Unit, added tests.

⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test) that use sdr-api*** (e.g.create_object_h2_spec.rb) and/or test in [stage|qa] environment, in addition to specs. ⚡


