### PR TITLE
Requesting a new token upon UnauthorizedError

### DIFF
--- a/lib/globus_client/identity.rb
+++ b/lib/globus_client/identity.rb
@@ -20,7 +20,8 @@ class GlobusClient
     def exists?(user_id)
       get_identity_id(user_id)
       true
-    rescue
+    # if no active user is returned
+    rescue RuntimeError
       false
     end
 

--- a/lib/globus_client/token_wrapper.rb
+++ b/lib/globus_client/token_wrapper.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class GlobusClient
+  # Wraps API operations to request new access token if expired
+  class TokenWrapper
+    def self.refresh(config, &block)
+      yield
+    rescue UnexpectedResponse::UnauthorizedError
+      config.token = Authenticator.token(config.client_id, config.client_secret, config.auth_url)
+      yield
+    end
+  end
+end

--- a/spec/globus_client/identity_spec.rb
+++ b/spec/globus_client/identity_spec.rb
@@ -56,15 +56,15 @@ RSpec.describe GlobusClient::Identity do
     end
   end
 
-  context "with user not active in Globus" do
+  context "with user not existing in Globus" do
     let(:identity_response) do
       {
         identities: [{
-          name: "Jane Tester",
-          email: user_id,
+          name: "None",
+          email: "None",
           id: "12345abc",
-          organization: "Stanford University",
-          identity_type: "login",
+          organization: "None",
+          identity_type: "None",
           username: user_id,
           identity_provider: "example-identity-provider",
           status: "unused"
@@ -142,8 +142,16 @@ RSpec.describe GlobusClient::Identity do
         .to_return(status: 401, body: identity_response.to_json)
     end
 
-    it "raises an UnauthorizedError" do
-      expect { identity.get_identity_id(user_id) }.to raise_error(GlobusClient::UnexpectedResponse::UnauthorizedError)
+    describe "#get_identity_id" do
+      it "raises an UnauthorizedError" do
+        expect { identity.get_identity_id(user_id) }.to raise_error(GlobusClient::UnexpectedResponse::UnauthorizedError)
+      end
+    end
+
+    describe "#exists?" do
+      it "raises an UnauthorizedError" do
+        expect { identity.exists?(user_id) }.to raise_error(GlobusClient::UnexpectedResponse::UnauthorizedError)
+      end
     end
   end
 end


### PR DESCRIPTION
## Why was this change made? 🤔
Resolves [sul-dlss/happy-heron](https://github.com/sul-dlss/happy-heron/issues/2937) to request a new token once upon an API 401 response (UnauthorizedError). 


## How was this change tested? 🤨
Unit.

⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test) that use sdr-api*** (e.g.create_object_h2_spec.rb) and/or test in [stage|qa] environment, in addition to specs. ⚡


