### PR TITLE
Add ability to ask endpoint if it contains any files

### DIFF
--- a/api_test.rb
+++ b/api_test.rb
@@ -30,6 +30,10 @@ Benchmark.bm(20) do |benchmark|
     @before_permissions = GlobusClient::Endpoint.new(GlobusClient.config, user_id:, path:).send(:access_rule)["permissions"]
   end
 
+  benchmark.report("has_files?:") do
+    @has_files = GlobusClient.has_files?(user_id:, path:)
+  end
+
   benchmark.report("list_files:") do
     GlobusClient.list_files(user_id:, path:) do |files|
       @files_count = files.count
@@ -49,6 +53,7 @@ Benchmark.bm(20) do |benchmark|
 
   puts "User #{user_id} exists: #{@user_exists}"
   puts "Initial directory permissions: #{@before_permissions}"
+  puts "Directory has files? #{@has_files}"
   puts "Number of files in directory: #{@files_count}"
   puts "Total size of files in directory: #{@total_size}"
   puts "List of files in directory: #{@files_list}"

--- a/lib/globus_client.rb
+++ b/lib/globus_client.rb
@@ -34,7 +34,8 @@ class GlobusClient
       self
     end
 
-    delegate :config, :disallow_writes, :file_count, :list_files, :mkdir, :total_size, :user_exists?, :get_filenames, to: :instance
+    delegate :config, :disallow_writes, :file_count, :list_files, :mkdir, :total_size,
+      :user_exists?, :get_filenames, :has_files?, to: :instance
 
     def default_transfer_url
       "https://transfer.api.globusonline.org"
@@ -90,6 +91,13 @@ class GlobusClient
     TokenWrapper.refresh(config) do
       endpoint = Endpoint.new(config, ...)
       endpoint.list_files { |files| return files.map(&:name) }
+    end
+  end
+
+  def has_files?(...)
+    TokenWrapper.refresh(config) do
+      endpoint = Endpoint.new(config, ...)
+      endpoint.has_files?
     end
   end
 

--- a/lib/globus_client/endpoint.rb
+++ b/lib/globus_client/endpoint.rb
@@ -16,6 +16,10 @@ class GlobusClient
       @path = path
     end
 
+    def has_files?
+      ls_path(full_path, [], return_presence: true)
+    end
+
     def list_files
       ls_path(full_path, []).tap do |files|
         yield files if block_given?
@@ -95,22 +99,33 @@ class GlobusClient
       path.split(PATH_SEPARATOR)
     end
 
+    # List files recursively at an endpoint https://docs.globus.org/api/transfer/file_operations/#list_directory_contents
     # @param filepath [String] an absolute path to look up contents e.g. /uploads/example/work123/version1
     # @param files [Array<FileInfo>] an array of FileInfo structs, each of which has a name and a size
-    def ls_path(filepath, files)
-      # List files recursively at an endpoint https://docs.globus.org/api/transfer/file_operations/#list_directory_contents
+    # @param return_presence [Boolean] if true, return a boolean to indicate if any files at all are present, short-circuiting the recursive operation
+    def ls_path(filepath, files, return_presence: false)
       response = connection.get("#{transfer_path}/ls?path=#{filepath}")
-      if response.success?
-        data = JSON.parse(response.body)["DATA"]
-        data
-          .select { |object| object["type"] == "file" }
-          .each { |file| files << FileInfo.new("#{filepath}#{file["name"]}", file["size"]) }
-        data
-          .select { |object| object["type"] == "dir" }
-          .each { |dir| ls_path("#{filepath}#{dir["name"]}/", files) }
-      else
-        UnexpectedResponse.call(response)
+      return UnexpectedResponse.call(response) unless response.success?
+
+      data = JSON.parse(response.body)["DATA"]
+      data
+        .select { |object| object["type"] == "file" }
+        .each do |file|
+        return true if return_presence
+
+        files << FileInfo.new("#{filepath}#{file["name"]}", file["size"])
       end
+      data
+        .select { |object| object["type"] == "dir" }
+        .each do |dir|
+        # NOTE: This allows the recursive method to short-circuit iff ls_path
+        #       returns true, which only happens when return_presence is true
+        #       and the first file is found in the ls operation.
+        return true if ls_path("#{filepath}#{dir["name"]}/", files, return_presence:) == true
+      end
+
+      return false if return_presence
+
       files
     end
 

--- a/lib/globus_client/endpoint.rb
+++ b/lib/globus_client/endpoint.rb
@@ -90,6 +90,8 @@ class GlobusClient
     end
 
     def path_segments
+      raise ArgumentError, "Unexpected path provided: #{path.inspect}" unless path.respond_to?(:split)
+
       path.split(PATH_SEPARATOR)
     end
 

--- a/spec/globus_client/endpoint_spec.rb
+++ b/spec/globus_client/endpoint_spec.rb
@@ -427,6 +427,269 @@ RSpec.describe GlobusClient::Endpoint do
     end
   end
 
+  describe "#has_files?" do
+    let(:path) { "example/work123/version1" }
+    let(:list_response1) do
+      {DATA: [{DATA_TYPE: "file",
+               group: "globus",
+               last_modified: "2022-12-07 19:23:33+00:00",
+               link_group: nil,
+               link_last_modified: nil,
+               link_size: nil,
+               link_target: nil,
+               link_user: nil,
+               name: "data",
+               permissions: "0755",
+               size: 3,
+               type: "dir",
+               user: "globus"},
+        {DATA_TYPE: "file",
+         group: "globus",
+         last_modified: "2022-12-07 19:23:33+00:00",
+         link_group: nil,
+         link_last_modified: nil,
+         link_size: nil,
+         link_target: nil,
+         link_user: nil,
+         name: "outputs",
+         permissions: "0755",
+         size: 3,
+         type: "dir",
+         user: "globus"},
+        {DATA_TYPE: "file",
+         group: "globus",
+         last_modified: "2022-12-07 22:41:54+00:00",
+         link_group: nil,
+         link_last_modified: nil,
+         link_size: nil,
+         link_target: nil,
+         link_user: nil,
+         name: "README.txt",
+         permissions: "0644",
+         size: 10,
+         type: "file",
+         user: "globus"}],
+       DATA_TYPE: "file_list",
+       absolute_path: "/uploads/example/work1234/version1/",
+       endpoint: "e32f7087-d32d-4588-8517-b2d0d32d53b8",
+       length: 1,
+       path: "/uploads/example/work1234/version1/",
+       rename_supported: true,
+       symlink_supported: false,
+       total: 2}
+    end
+    let(:list_path2) { "example/work123/version1/data" }
+    let(:list_response2) do
+      {DATA: [{DATA_TYPE: "file",
+               group: "globus",
+               last_modified: "2022-12-07 19:23:33+00:00",
+               link_group: nil,
+               link_last_modified: nil,
+               link_size: nil,
+               link_target: nil,
+               link_user: nil,
+               name: "test.txt",
+               permissions: "0755",
+               size: 3,
+               type: "file",
+               user: "globus"}],
+       DATA_TYPE: "file_list",
+       absolute_path: "/uploads/example/work123/version1/data/",
+       endpoint: "1234",
+       length: 1,
+       path: "/uploads/example/work123/version1/data/",
+       total: 1}
+    end
+    let(:list_path3) { "example/work123/version1/outputs" }
+    let(:list_response3) do
+      {DATA: [{DATA_TYPE: "file",
+               group: "globus",
+               last_modified: "2022-12-07 19:23:33+00:00",
+               link_group: nil,
+               link_last_modified: nil,
+               link_size: nil,
+               link_target: nil,
+               link_user: nil,
+               name: "output.txt",
+               permissions: "0755",
+               size: 3,
+               type: "file",
+               user: "globus"}],
+       DATA_TYPE: "file_list",
+       absolute_path: "/uploads/example/work123/version1/outputs/",
+       endpoint: "1234",
+       length: 1,
+       path: "/uploads/example/work123/version1/outputs/",
+       total: 1}
+    end
+
+    context "when path is empty" do
+      let(:empty_response) do
+        {DATA: [],
+         DATA_TYPE: "file_list",
+         absolute_path: "/uploads/example/work1234/version1/",
+         endpoint: "e32f7087-d32d-4588-8517-b2d0d32d53b8",
+         length: 0,
+         path: "/uploads/example/work1234/version1/",
+         rename_supported: true,
+         symlink_supported: false,
+         total: 0}
+      end
+
+      before do
+        stub_request(:get, "#{config.transfer_url}/v0.10/operation/endpoint/#{transfer_endpoint_id}/ls?path=/uploads/#{path}/")
+          .to_return(status: 200, body: empty_response.to_json)
+      end
+
+      it "returns false" do
+        expect(endpoint).not_to have_files
+      end
+    end
+
+    context "when path has one or more empty subdirectories" do
+      let(:empty_response) do
+        {DATA: [],
+         DATA_TYPE: "file_list",
+         absolute_path: "/uploads/example/work1234/version1/data/",
+         endpoint: "e32f7087-d32d-4588-8517-b2d0d32d53b8",
+         length: 0,
+         path: "/uploads/example/work1234/version1/data/",
+         rename_supported: true,
+         symlink_supported: false,
+         total: 0}
+      end
+      let(:single_directory_response) do
+        {DATA: [{DATA_TYPE: "file",
+                 group: "globus",
+                 last_modified: "2022-12-07 19:23:33+00:00",
+                 link_group: nil,
+                 link_last_modified: nil,
+                 link_size: nil,
+                 link_target: nil,
+                 link_user: nil,
+                 name: "data",
+                 permissions: "0755",
+                 size: 0,
+                 type: "dir",
+                 user: "globus"}],
+         DATA_TYPE: "file_list",
+         absolute_path: "/uploads/example/work1234/version1/",
+         endpoint: "e32f7087-d32d-4588-8517-b2d0d32d53b8",
+         length: 1,
+         path: "/uploads/example/work1234/version1/",
+         rename_supported: true,
+         symlink_supported: false,
+         total: 1}
+      end
+
+      before do
+        stub_request(:get, "#{config.transfer_url}/v0.10/operation/endpoint/#{transfer_endpoint_id}/ls?path=/uploads/#{path}/")
+          .to_return(status: 200, body: single_directory_response.to_json)
+        stub_request(:get, "#{config.transfer_url}/v0.10/operation/endpoint/#{transfer_endpoint_id}/ls?path=/uploads/#{path}/data/")
+          .to_return(status: 200, body: empty_response.to_json)
+      end
+
+      it "returns false" do
+        expect(endpoint).not_to have_files
+      end
+    end
+
+    context "when path has a file" do
+      let(:single_file_response) do
+        {DATA: [{DATA_TYPE: "file",
+                 group: "globus",
+                 last_modified: "2022-12-07 19:23:33+00:00",
+                 link_group: nil,
+                 link_last_modified: nil,
+                 link_size: nil,
+                 link_target: nil,
+                 link_user: nil,
+                 name: "README.txt",
+                 permissions: "0755",
+                 size: 3,
+                 type: "file",
+                 user: "globus"}],
+         DATA_TYPE: "file_list",
+         absolute_path: "/uploads/example/work1234/version1/",
+         endpoint: "e32f7087-d32d-4588-8517-b2d0d32d53b8",
+         length: 1,
+         path: "/uploads/example/work1234/version1/",
+         rename_supported: true,
+         symlink_supported: false,
+         total: 1}
+      end
+
+      before do
+        stub_request(:get, "#{config.transfer_url}/v0.10/operation/endpoint/#{transfer_endpoint_id}/ls?path=/uploads/#{path}/")
+          .to_return(status: 200, body: single_file_response.to_json)
+      end
+
+      it "returns true" do
+        expect(endpoint).to have_files
+      end
+    end
+
+    context "when path has a file in one or more subdirectories" do
+      let(:single_directory_response) do
+        {DATA: [{DATA_TYPE: "file",
+                 group: "globus",
+                 last_modified: "2022-12-07 19:23:33+00:00",
+                 link_group: nil,
+                 link_last_modified: nil,
+                 link_size: nil,
+                 link_target: nil,
+                 link_user: nil,
+                 name: "data",
+                 permissions: "0755",
+                 size: 0,
+                 type: "dir",
+                 user: "globus"}],
+         DATA_TYPE: "file_list",
+         absolute_path: "/uploads/example/work1234/version1/",
+         endpoint: "e32f7087-d32d-4588-8517-b2d0d32d53b8",
+         length: 1,
+         path: "/uploads/example/work1234/version1/",
+         rename_supported: true,
+         symlink_supported: false,
+         total: 1}
+      end
+      let(:single_file_response) do
+        {DATA: [{DATA_TYPE: "file",
+                 group: "globus",
+                 last_modified: "2022-12-07 19:23:33+00:00",
+                 link_group: nil,
+                 link_last_modified: nil,
+                 link_size: nil,
+                 link_target: nil,
+                 link_user: nil,
+                 name: "README.txt",
+                 permissions: "0755",
+                 size: 3,
+                 type: "file",
+                 user: "globus"}],
+         DATA_TYPE: "file_list",
+         absolute_path: "/uploads/example/work1234/version1/data/",
+         endpoint: "e32f7087-d32d-4588-8517-b2d0d32d53b8",
+         length: 1,
+         path: "/uploads/example/work1234/version1/data/",
+         rename_supported: true,
+         symlink_supported: false,
+         total: 1}
+      end
+
+      before do
+        stub_request(:get, "#{config.transfer_url}/v0.10/operation/endpoint/#{transfer_endpoint_id}/ls?path=/uploads/#{path}/")
+          .to_return(status: 200, body: single_directory_response.to_json)
+        stub_request(:get, "#{config.transfer_url}/v0.10/operation/endpoint/#{transfer_endpoint_id}/ls?path=/uploads/#{path}/data/")
+          .to_return(status: 200, body: single_file_response.to_json)
+      end
+
+      it "returns true" do
+        expect(endpoint).to have_files
+      end
+    end
+  end
+
   describe "#list_files" do
     context "with an unsplittable (e.g., nil) path" do
       let(:path) { nil }

--- a/spec/globus_client/endpoint_spec.rb
+++ b/spec/globus_client/endpoint_spec.rb
@@ -565,7 +565,26 @@ RSpec.describe GlobusClient::Endpoint do
           expect { endpoint.list_files }.to raise_error(GlobusClient::UnexpectedResponse::ResourceNotFound)
         end
       end
-      # rubocop:enable RSpec/NestedGroups
     end
+
+    context "with an unsplittable (e.g., nil) path" do
+      let(:path) { nil }
+      let(:not_found_response) do
+        {code: "ClientError.NotFound",
+         message: "Directory '#{path}' not found on endpoint"}
+      end
+
+      before do
+        stub_request(:get, "#{config.transfer_url}/v0.10/operation/endpoint/#{transfer_endpoint_id}/ls?path=/uploads/#{path}/")
+          .to_return(status: 404, body: not_found_response.to_json)
+      end
+
+      describe "#list_files" do
+        it "raises an ArgumentError" do
+          expect { endpoint.list_files }.to raise_error(ArgumentError, /Unexpected path provided: nil/)
+        end
+      end
+    end
+    # rubocop:enable RSpec/NestedGroups
   end
 end

--- a/spec/globus_client_spec.rb
+++ b/spec/globus_client_spec.rb
@@ -175,7 +175,7 @@ RSpec.describe GlobusClient do
   end
 
   # Test public API methods in the client that are sent to the Endpoint using the same names
-  [:disallow_writes, :list_files, :mkdir].each do |method|
+  [:disallow_writes, :has_files?, :list_files, :mkdir].each do |method|
     describe ".#{method}" do
       let(:fake_instance) { instance_double(described_class) }
 


### PR DESCRIPTION
## Why was this change made? 🤔

* Add ability to ask endpoint if it contains any files
  * Supports work in H2 preventing users from depositing works with no Globus files. The recursive endpoint listing can be very expensive, so we expose a new public method for asking if any files are present, short-circuiting the recursive operation as soon as a single file is found.
* Raise exception in Endpoint if supplied a path that is unsplittable
  * Fixes a bug that I found while working on a Globus-related feature in H2, caused when consumers fail to provide a valid path argument to endpoint operations.
* Refactor endpoint spec for more idiomatic context/describe usage
  * Groups the `Endpoint#list_files` tests together under a single `describe` for the operation, which lets us remove one or two unnecessary levels of nesting and is more consistent with other RSpec tests in our codebases.

## How was this change tested? 🤨

CI + api_test.rb
