### PR TITLE
Retry failed connections

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,6 +4,7 @@ PATH
     globus_client (0.9.1)
       activesupport (>= 4.2, < 8)
       faraday
+      faraday-retry
       zeitwerk
 
 GEM
@@ -27,6 +28,8 @@ GEM
       faraday-net_http (>= 2.0, < 3.1)
       ruby2_keywords (>= 0.0.4)
     faraday-net_http (3.0.2)
+    faraday-retry (2.0.0)
+      faraday (~> 2.0)
     hashdiff (1.0.1)
     i18n (1.12.0)
       concurrent-ruby (~> 1.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    globus_client (0.9.0)
+    globus_client (0.9.1)
       activesupport (>= 4.2, < 8)
       faraday
       zeitwerk
@@ -99,6 +99,7 @@ PLATFORMS
   x86_64-darwin-19
   x86_64-darwin-20
   x86_64-darwin-21
+  x86_64-darwin-22
   x86_64-linux
 
 DEPENDENCIES

--- a/globus_client.gemspec
+++ b/globus_client.gemspec
@@ -33,6 +33,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "activesupport", ">= 4.2", "< 8"
   spec.add_dependency "faraday"
+  spec.add_dependency "faraday-retry"
   spec.add_dependency "zeitwerk"
 
   spec.add_development_dependency "rake", "~> 13.0"

--- a/lib/globus_client.rb
+++ b/lib/globus_client.rb
@@ -2,6 +2,7 @@
 
 require "active_support/core_ext/module/delegation"
 require "faraday"
+require "faraday/retry"
 require "ostruct"
 require "singleton"
 require "zeitwerk"

--- a/lib/globus_client/endpoint.rb
+++ b/lib/globus_client/endpoint.rb
@@ -65,8 +65,10 @@ class GlobusClient
     attr_reader :config, :path, :user_id
 
     def connection
-      # Transfer API connection
-      @connection ||= Faraday.new(
+      # Creates a new connection every time to avoid firewall timeouts when
+      # doing many requests over one connection.
+      # https://github.com/sul-dlss/happy-heron/issues/3008
+      Faraday.new(
         url: config.transfer_url,
         headers: {Authorization: "Bearer #{config.token}"}
       )

--- a/lib/globus_client/endpoint.rb
+++ b/lib/globus_client/endpoint.rb
@@ -65,13 +65,20 @@ class GlobusClient
     attr_reader :config, :path, :user_id
 
     def connection
-      # Creates a new connection every time to avoid firewall timeouts when
-      # doing many requests over one connection.
-      # https://github.com/sul-dlss/happy-heron/issues/3008
-      Faraday.new(
+      # faraday/retry is used here to catch Faraday::ConnectionFailed exceptions
+      # see: https://github.com/sul-dlss/happy-heron/issues/3008
+      @connection ||= Faraday.new(
         url: config.transfer_url,
         headers: {Authorization: "Bearer #{config.token}"}
-      )
+      ) do |faraday|
+        faraday.request :retry, {
+          max: 10,
+          interval: 0.05,
+          interval_randomness: 0.5,
+          backoff_factor: 2,
+          exceptions: Faraday::Retry::Middleware::DEFAULT_EXCEPTIONS + [Faraday::ConnectionFailed]
+        }
+      end
     end
 
     def globus_identity_id

--- a/lib/globus_client/version.rb
+++ b/lib/globus_client/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 class GlobusClient
-  VERSION = "0.9.0"
+  VERSION = "0.9.1"
 end


### PR DESCRIPTION
## Why was this change made? 🤔

We have seen Faraday::ConnectionFailed exceptions in long running
list_files() calls with thousands of recursive API calls. These run
fine in development environments and on Stage, but not in Prod. While we
try to sort out if there is a networking issue we can retry these using faraday-retry.

For context see:

- https://github.com/sul-dlss/happy-heron/issues/3008
- https://github.com/sul-dlss/operations-tasks/issues/3306

## How was this change tested? 🤨

Unit tests.

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡

