### PR TITLE
Encode filepath to avoid invalid uri errors

### DIFF
--- a/lib/globus_client/endpoint.rb
+++ b/lib/globus_client/endpoint.rb
@@ -113,7 +113,7 @@ class GlobusClient
     # @param files [Array<FileInfo>] an array of FileInfo structs, each of which has a name and a size
     # @param return_presence [Boolean] if true, return a boolean to indicate if any files at all are present, short-circuiting the recursive operation
     def ls_path(filepath, files, return_presence: false)
-      response = connection.get("#{transfer_path}/ls?path=#{filepath}")
+      response = connection.get("#{transfer_path}/ls?path=#{CGI.escape(filepath)}")
       return UnexpectedResponse.call(response) unless response.success?
 
       data = JSON.parse(response.body)["DATA"]


### PR DESCRIPTION
## Why was this change made? 🤔

Fixes https://github.com/sul-dlss/happy-heron/issues/3237

I have been able to verify that this resolves the bug locally via the console. However, I'm a little unclear on how this may be tested (or if it should). I have a small test (not committed yet) that adds the filename that needs to be encoded, but I believe the test in place is mocking the calls to where we're avoiding the URI core calls that actually raise the error.

I'm going to leave this as-is but welcome pairing on testing, either in this PR or a follow up (or if we decide it's unnecessary).

## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡

