### PR TITLE
Raise error when no access rule to change

### DIFF
--- a/lib/globus_client/endpoint.rb
+++ b/lib/globus_client/endpoint.rb
@@ -57,7 +57,7 @@ class GlobusClient
 
     # Assign a user read-only permissions for a directory https://docs.globus.org/api/transfer/acl/#rest_access_create
     def disallow_writes
-      access_request(permissions: "r")
+      update_access_request(permissions: "r")
     end
 
     private
@@ -159,6 +159,22 @@ class GlobusClient
           }.to_json
           req.headers["Content-Type"] = "application/json"
         end
+      end
+
+      return true if response.success?
+
+      UnexpectedResponse.call(response)
+    end
+
+    def update_access_request(permissions:)
+      raise(StandardError, "Access rule not found for #{path}") if !access_rule_id
+
+      response = connection.put("#{access_path}/#{access_rule_id}") do |req|
+        req.body = {
+          DATA_TYPE: "access",
+          permissions:
+        }.to_json
+        req.headers["Content-Type"] = "application/json"
       end
 
       return true if response.success?


### PR DESCRIPTION
## Why was this change made? 🤔
Upon further reflection, the `disallow_writes` method should raise an error if you're trying to update a rule that does not exist. Also, the tests had been set up to pass when they should have failed in these cases. 

## How was this change tested? 🤨
Unit and QA deploy. Gem has no change to the public method and it's OK for this to be in the next release, which will also include deleting access rules. 

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡

