### PR TITLE
Do not authenticate as part of client configuration

### DIFF
--- a/api_test.rb
+++ b/api_test.rb
@@ -21,8 +21,8 @@ Benchmark.bm(20) do |benchmark|
     GlobusClient.mkdir(user_id:, path:)
   end
 
-  benchmark.report("user_exists?:") do
-    @user_exists = GlobusClient.user_exists?(user_id)
+  benchmark.report("user_valid?:") do
+    @user_exists = GlobusClient.user_valid?(user_id)
   end
 
   benchmark.report("before_perms:") do

--- a/lib/globus_client.rb
+++ b/lib/globus_client.rb
@@ -23,7 +23,17 @@ class GlobusClient
     # @param auth_url [String] the authentication API URL
     def configure(client_id:, client_secret:, uploads_directory:, transfer_endpoint_id:, transfer_url: default_transfer_url, auth_url: default_auth_url)
       instance.config = OpenStruct.new(
-        token: Authenticator.token(client_id, client_secret, auth_url),
+        # For the initial token, use a dummy value to avoid hitting any APIs
+        # during configuration, allowing the `TokenWrapper` to handle auto-magic
+        # token refreshing. Why not immediately get a valid token? Our apps
+        # commonly invoke client `.configure` methods in the initializer in all
+        # application environments, even those that are never expected to
+        # connect to production APIs, such as local development machines.
+        #
+        # NOTE: `nil` and blank string cannot be used as dummy values here as
+        # they lead to a malformed request to be sent, which triggers an
+        # exception not rescued by `TokenWrapper`
+        token: "a temporary dummy token to avoid hitting the API before it is needed",
         client_id:,
         client_secret:,
         uploads_directory:,

--- a/spec/globus_client_spec.rb
+++ b/spec/globus_client_spec.rb
@@ -62,8 +62,8 @@ RSpec.describe GlobusClient do
   end
 
   describe "#config" do
-    it "includes a token" do
-      expect(client.config.token).to be_nil
+    it "includes a dummy token" do
+      expect(client.config.token).to eq("a temporary dummy token to avoid hitting the API before it is needed")
     end
 
     it "includes an uploads directory" do
@@ -118,7 +118,7 @@ RSpec.describe GlobusClient do
 
       before do
         allow(described_class::Identity).to receive(:new).and_return(fake_identity)
-        allow(GlobusClient::Authenticator).to receive(:token).and_return("a_token", "new_token")
+        allow(GlobusClient::Authenticator).to receive(:token).and_return("new_token")
         response_values = [:raise, true]
         allow(fake_identity).to receive(:valid?).twice do
           v = response_values.shift
@@ -129,7 +129,7 @@ RSpec.describe GlobusClient do
       it "fetches a new token and retries Identity#valid?" do
         expect { client.user_valid?(sunetid: "user") }
           .to change(client.config, :token)
-          .from("a_token")
+          .from("a temporary dummy token to avoid hitting the API before it is needed")
           .to("new_token")
       end
     end


### PR DESCRIPTION
# Why was this change made?

For the initial token, use a dummy value to avoid hitting any APIs during configuration, allowing the `TokenWrapper` to handle auto-magic token refreshing. Why not immediately get a valid token? Our apps commonly invoke client `.configure` methods in the initializer in all application environments, even those that are never expected to connect to production APIs, such as local development machines.

NOTE: `nil` and blank string cannot be used as dummy values here as they lead to a malformed request to be sent, which triggers an exception not rescued by `TokenWrapper`

# How was this change tested?

CI, ran `api_test.rb` successfully
