### PR TITLE
raise UnexpectedResponse when an error occurs

### DIFF
--- a/lib/globus_client/endpoint.rb
+++ b/lib/globus_client/endpoint.rb
@@ -199,7 +199,8 @@ class GlobusClient
 
       # debugging of Globus responses
       response_body = JSON.parse(response.body)
-      raise(StandardError, "Response is missing DATA in: #{response_body}") unless response_body.key?("DATA")
+
+      UnexpectedResponse.call(response, message: "Response is missing DATA in: #{response_body}") unless response.success? && response_body.key?("DATA")
 
       JSON
         .parse(response.body)["DATA"]

--- a/lib/globus_client/unexpected_response.rb
+++ b/lib/globus_client/unexpected_response.rb
@@ -26,7 +26,7 @@ class GlobusClient
     # https://docs.globus.org/api/transfer/file_operations/#errors
     # https://docs.globus.org/api/transfer/acl/#common_errors
     # https://docs.globus.org/api/auth/reference/
-    def self.call(response)
+    def self.call(response, message: "")
       case response.status
       when 400
         raise BadRequestError, "Invalid path or another error with the request: #{response.body}"
@@ -37,11 +37,11 @@ class GlobusClient
       when 404
         raise ResourceNotFound, "Endpoint ID not found or resource does not exist: #{response.body}"
       when 502
-        raise EndpointError, "Other error with endpoint: #{response.body}"
+        raise EndpointError, "Other error with endpoint: #{response.status} #{response.body}. #{message}"
       when 503
         raise ServiceUnavailable, "The service is down for maintenance."
       else
-        raise StandardError, "Unexpected response: #{response.status} #{response.body}"
+        raise StandardError, "Unexpected response: #{response.status} #{response.body}. #{message}"
       end
     end
   end

--- a/spec/globus_client/endpoint_spec.rb
+++ b/spec/globus_client/endpoint_spec.rb
@@ -512,6 +512,17 @@ RSpec.describe GlobusClient::Endpoint do
     end
   end
 
+  context "when the token needs to be refreshed" do
+    before do
+      stub_request(:post, "#{config.transfer_url}/v0.10/operation/endpoint/#{transfer_endpoint_id}/mkdir")
+        .to_return(status: 401, body: {}.to_json)
+    end
+
+    it "raises an UnexpectedResponse" do
+      expect { endpoint.mkdir }.to raise_error(GlobusClient::UnexpectedResponse::UnauthorizedError)
+    end
+  end
+
   describe "#has_files?" do
     let(:path) { "example/work123/version1" }
     let(:list_response1) do


### PR DESCRIPTION
## Why was this change made? 🤔

Fixes #113 - use the `UnexpectedResponse` exception when an error occurs, so it can be correctly caught by the `TokenRefresh` logic.  Add in the ability to pass in a custom message for logging the exception too.

## How was this change tested? 🤨

Added a new spec