### PR TITLE
allow the user to skip notifying email

### DIFF
--- a/lib/globus_client/endpoint.rb
+++ b/lib/globus_client/endpoint.rb
@@ -10,10 +10,11 @@ class GlobusClient
     # @param client [GlobusClient] a configured instance of the GlobusClient
     # @param path [String] the path to operate on
     # @param user_id [String] a Globus user ID (e.g., a @stanford.edu email address)
-    def initialize(client, path:, user_id:)
+    def initialize(client, path:, user_id:, notify_email: true)
       @client = client
       @user_id = user_id
       @path = path
+      @notify_email = notify_email
     end
 
     def has_files?
@@ -63,7 +64,7 @@ class GlobusClient
 
     private
 
-    attr_reader :client, :path, :user_id
+    attr_reader :client, :path, :user_id, :notify_email
 
     def globus_identity_id
       Identity.new(client).get_identity_id(user_id)
@@ -129,17 +130,18 @@ class GlobusClient
       if access_rule_id
         update_access_request(permissions:)
       else
+        body = {
+          DATA_TYPE: 'access',
+          principal_type: 'identity',
+          principal: globus_identity_id,
+          path: full_path,
+          permissions:
+        }
+        body[:notify_email] = user_id if notify_email
         client.post(
           base_url: client.config.transfer_url,
           path: access_path,
-          body: {
-            DATA_TYPE: 'access',
-            principal_type: 'identity',
-            principal: globus_identity_id,
-            path: full_path,
-            permissions:,
-            notify_email: user_id
-          }
+          body:
         )
       end
     end

--- a/lib/globus_client/endpoint.rb
+++ b/lib/globus_client/endpoint.rb
@@ -10,6 +10,7 @@ class GlobusClient
     # @param client [GlobusClient] a configured instance of the GlobusClient
     # @param path [String] the path to operate on
     # @param user_id [String] a Globus user ID (e.g., a @stanford.edu email address)
+    # @param notify_email [Boolean] indicates if we should ask Globus to send emails on access change (default: true)
     def initialize(client, path:, user_id:, notify_email: true)
       @client = client
       @user_id = user_id


### PR DESCRIPTION
## Why was this change made? 🤔

Allow consumers of the client to ask Globus to skip sending emails.  Defaults to "true" so will send email unless you opt out when initializing the client.

## How was this change tested? 🤨

New spec

