### PR TITLE
Prefer using the singleton instance over passing around instance and config objects

### DIFF
--- a/lib/globus_client.rb
+++ b/lib/globus_client.rb
@@ -140,7 +140,7 @@ class GlobusClient # rubocop:disable Metrics/ClassLength
   end
 
   def mkdir(...)
-    Endpoint.new(self, ...).tap do |endpoint|
+    Endpoint.new(...).tap do |endpoint|
       endpoint.mkdir
       endpoint.allow_writes
     end
@@ -148,13 +148,13 @@ class GlobusClient # rubocop:disable Metrics/ClassLength
 
   def disallow_writes(...)
     Endpoint
-      .new(self, ...)
+      .new(...)
       .disallow_writes
   end
 
   def delete_access_rule(...)
     Endpoint
-      .new(self, ...)
+      .new(...)
       .delete_access_rule
   end
 
@@ -163,37 +163,37 @@ class GlobusClient # rubocop:disable Metrics/ClassLength
   #       `Endpoint#list_files`
   def list_files(**keywords, &)
     Endpoint
-      .new(self, **keywords)
+      .new(**keywords)
       .list_files(&)
   end
 
   def file_count(...)
     Endpoint
-      .new(self, ...)
+      .new(...)
       .list_files { |files| return files.count }
   end
 
   def total_size(...)
     Endpoint
-      .new(self, ...)
+      .new(...)
       .list_files { |files| return files.sum(&:size) }
   end
 
   def get_filenames(...)
     Endpoint
-      .new(self, ...)
+      .new(...)
       .list_files { |files| return files.map(&:name) }
   end
 
   def has_files?(...)
     Endpoint
-      .new(self, ...)
+      .new(...)
       .has_files?
   end
 
   def user_valid?(...)
     Identity
-      .new(self)
+      .new
       .valid?(...)
   end
 
@@ -230,7 +230,7 @@ class GlobusClient # rubocop:disable Metrics/ClassLength
 
     # if unauthorized, token has likely expired. try to get a new token and then retry the same request(s).
     if response.status == 401
-      config.token = Authenticator.token(config.client_id, config.client_secret, config.auth_url)
+      config.token = Authenticator.token
       response = yield
     end
 

--- a/lib/globus_client/authenticator.rb
+++ b/lib/globus_client/authenticator.rb
@@ -3,14 +3,8 @@
 class GlobusClient
   # The namespace for the "login" command
   class Authenticator
-    def self.token(client_id, client_secret, auth_url)
-      new(client_id, client_secret, auth_url).token
-    end
-
-    def initialize(client_id, client_secret, auth_url)
-      @client_id = client_id
-      @client_secret = client_secret
-      @auth_url = auth_url
+    def self.token
+      new.token
     end
 
     # Request an access_token
@@ -24,16 +18,14 @@ class GlobusClient
 
     private
 
-    attr_reader :client_id, :client_secret, :auth_url
-
     def connection
-      Faraday.new(url: auth_url)
+      Faraday.new(url: GlobusClient.config.auth_url)
     end
 
     def form_data
       {
-        client_id:,
-        client_secret:,
+        client_id: GlobusClient.config.client_id,
+        client_secret: GlobusClient.config.client_secret,
         encoding: 'form',
         grant_type: 'client_credentials',
         scope: 'urn:globus:auth:scope:transfer.api.globus.org:all'

--- a/lib/globus_client/identity.rb
+++ b/lib/globus_client/identity.rb
@@ -3,15 +3,11 @@
 class GlobusClient
   # Lookup of a Globus identity ID
   class Identity
-    def initialize(client)
-      @client = client
-    end
-
     # @param user_id [String] the username in the form of an email addresss
     # @return [Hash] id and status of Globus identity
     def get_identity(user_id)
-      response = client.get(
-        base_url: client.config.auth_url,
+      response = GlobusClient.instance.get(
+        base_url: GlobusClient.config.auth_url,
         path: '/v2/api/identities',
         params: { usernames: user_id }
       )
@@ -30,9 +26,5 @@ class GlobusClient
     def get_identity_id(user_id)
       get_identity(user_id)['id']
     end
-
-    private
-
-    attr_reader :client
   end
 end

--- a/spec/globus_client/authenticator_spec.rb
+++ b/spec/globus_client/authenticator_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe GlobusClient::Authenticator do
 
   describe '.token' do
     let(:instance) do
-      described_class.new(client_id, client_secret, auth_url)
+      described_class.new
     end
 
     before do
@@ -31,13 +31,23 @@ RSpec.describe GlobusClient::Authenticator do
     end
 
     it 'invokes #token on a new instance' do
-      described_class.token(client_id, client_secret, auth_url)
+      described_class.token
       expect(instance).to have_received(:token).once
     end
   end
 
   describe '#token' do
-    subject(:authenticator) { described_class.new(client_id, client_secret, auth_url) }
+    subject(:authenticator) { described_class.new }
+
+    before do
+      GlobusClient.configure(
+        auth_url:,
+        client_id:,
+        client_secret:,
+        transfer_endpoint_id: 'not_a_real_endpoint',
+        uploads_directory: '/fake_uploads/'
+      )
+    end
 
     it 'parses the token from the response' do
       expect(authenticator.token).to eq 'a_long_silly_token'

--- a/spec/globus_client/endpoint_spec.rb
+++ b/spec/globus_client/endpoint_spec.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
 RSpec.describe GlobusClient::Endpoint do
-  subject(:endpoint) { described_class.new(client, user_id:, path:) }
+  subject(:endpoint) { described_class.new(user_id:, path:) }
 
-  let(:client) do
+  before do
     GlobusClient.configure(
       client_id: 'client_id',
       client_secret: 'client_secret',
@@ -12,6 +12,7 @@ RSpec.describe GlobusClient::Endpoint do
       uploads_directory:
     )
   end
+
   let(:transfer_endpoint_id) { 'NOT_A_REAL_ENDPOINT' }
   let(:transfer_url) { 'https://transfer.api.example.org' }
   let(:uploads_directory) { '/uploads/' }
@@ -522,7 +523,7 @@ RSpec.describe GlobusClient::Endpoint do
 
   context 'when the token needs to be refreshed' do
     before do
-      stub_request(:post, "#{client.config.auth_url}/v2/oauth2/token")
+      stub_request(:post, "#{GlobusClient.config.auth_url}/v2/oauth2/token")
         .to_return(
           { status: 200, body: '{"access_token" : "new_token"}' }
         )
@@ -951,7 +952,7 @@ RSpec.describe GlobusClient::Endpoint do
   end
 
   context 'with notify email setting' do
-    subject(:endpoint) { described_class.new(client, user_id:, path:, notify_email:) }
+    subject(:endpoint) { described_class.new(user_id:, path:, notify_email:) }
 
     let(:fake_identity) { instance_double(GlobusClient::Identity, get_identity_id: 'example') }
     let(:access_list_response) do
@@ -976,7 +977,7 @@ RSpec.describe GlobusClient::Endpoint do
 
     before do
       allow(GlobusClient::Identity).to receive(:new).and_return(fake_identity)
-      allow(client).to receive(:post)
+      allow(GlobusClient.instance).to receive(:post)
       stub_request(:get, "#{transfer_url}/v0.10/endpoint/#{transfer_endpoint_id}/access_list")
         .to_return(status: 200, body: access_list_response.to_json)
     end
@@ -995,7 +996,7 @@ RSpec.describe GlobusClient::Endpoint do
 
       it 'leaves off notify_email parameter for when setting access' do
         endpoint.allow_writes
-        expect(client).to have_received(:post).with(params)
+        expect(GlobusClient.instance).to have_received(:post).with(params)
       end
     end
 
@@ -1014,7 +1015,7 @@ RSpec.describe GlobusClient::Endpoint do
 
       it 'adds notify_email parameter for when setting access' do
         endpoint.allow_writes
-        expect(client).to have_received(:post).with(params)
+        expect(GlobusClient.instance).to have_received(:post).with(params)
       end
     end
   end

--- a/spec/globus_client/identity_spec.rb
+++ b/spec/globus_client/identity_spec.rb
@@ -1,10 +1,9 @@
 # frozen_string_literal: true
 
 RSpec.describe GlobusClient::Identity do
-  subject(:identity) { described_class.new(client) }
+  subject(:identity) { described_class.new }
 
-  let(:auth_url) { 'https://auth.example.org' }
-  let(:client) do
+  before do
     GlobusClient.configure(
       auth_url:,
       client_id: 'client_id',
@@ -13,6 +12,8 @@ RSpec.describe GlobusClient::Identity do
       uploads_directory: '/fake_uploads/'
     )
   end
+
+  let(:auth_url) { 'https://auth.example.org' }
   let(:user_id) { 'example@stanford.edu' }
   let(:token_response) do
     {

--- a/spec/globus_client_spec.rb
+++ b/spec/globus_client_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe GlobusClient do
   end
 
   it 'has a version number' do
-    expect(GlobusClient::VERSION).not_to be_nil
+    expect(described_class::VERSION).not_to be_nil
   end
 
   it 'has singleton behavior' do
@@ -144,12 +144,12 @@ RSpec.describe GlobusClient do
 
       before do
         allow(described_class::Identity).to receive(:new).and_return(fake_identity)
-        allow(GlobusClient::Authenticator).to receive(:token).and_return('a_token', 'new_token')
-        allow(fake_identity).to receive(:valid?).and_raise(GlobusClient::UnexpectedResponse::UnauthorizedError)
+        allow(described_class::Authenticator).to receive(:token).and_return('a_token', 'new_token')
+        allow(fake_identity).to receive(:valid?).and_raise(described_class::UnexpectedResponse::UnauthorizedError)
       end
 
       it 'raises an error with Identity#valid?' do
-        expect { client.user_valid?('bogus') }.to raise_error(GlobusClient::UnexpectedResponse::UnauthorizedError)
+        expect { client.user_valid?('bogus') }.to raise_error(described_class::UnexpectedResponse::UnauthorizedError)
       end
     end
   end


### PR DESCRIPTION
# Why was this change made?

The `Endpoint`, `Authenticator`, and `Identity` classes all rely on the `GlobusClient` singleton instance already, and the instance injected at instantiation time is in practice identical to the one that is accessible via `GlobusClient.instance`, so simplify interfaces and dependencies by relying directly on the singleton instead of passing stuff around.

# How was this change tested?

CI
